### PR TITLE
chore: Add commit message prefix for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,13 @@ updates:
       interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
+    commit-message:
+      prefix: "chore"
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
       interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
I add the `prefix` of the `commit-message` option for Dependabot.