### PR TITLE
ci: Use Flutter instead of Dart for commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
       - name: Install dependencies
-        run: dart pub get
+        run: flutter pub get
 
       - name: Update version
-        run: dart run bull pub_version --version=${{ steps.semver.outputs.version }}
+        run: flutter run bull pub_version --version=${{ steps.semver.outputs.version }}
 
       - name: Commit updated pubspec
         uses: stefanzweifel/git-auto-commit-action@v4
@@ -72,4 +72,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
-        run: dart pub publish --force
+        run: flutter pub publish --force


### PR DESCRIPTION
I use Flutter instead of Dart for commands to fix the error.

- https://github.com/dev-yakuza/run_with_network_images/actions/runs/5068873067/jobs/9101725846