### PR TITLE
ci: Use Dart for command of updating version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         run: flutter pub get
 
       - name: Update version
-        run: flutter run bull pub_version --version=${{ steps.semver.outputs.version }}
+        run: dart run bull pub_version --version=${{ steps.semver.outputs.version }}
 
       - name: Commit updated pubspec
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
I use `dart` for the command of updating the version to fix the following error.

```bash
Run flutter run bull pub_version --version=0.0.1
Flag option "version" should not be given a value.

Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.
```

- Related: https://github.com/dev-yakuza/run_with_network_images/actions/runs/5069044260/jobs/9102111887